### PR TITLE
Fixes #1 Enum validation issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install pytest-schema
 
 Here is a quick example of using **`schema`**:
 ```python
-from pytest_schema import schema
+from pytest_schema import schema, exact, like
 
 article_v1 = {
     "id": int,
@@ -34,13 +34,26 @@ article_v1 = {
 
 def test_article_v1_endpoint(test_client):
     """
-    Test calling a article endpoint and validating its
-    response for a article is correctly formatted.
+    Test calling v1 endpoint and validating the response
+    is in the correctly/expected format.
     """
+    response_v1 = test_client.get("/api/v1/article/1")
+    assert exact(article_v1) == response_v1
+    # Same as:
+    # assert schema(article_v1) == response_v1
 
-    response = test_client.get("/api/v1/article/1")
+article_v2 = {
+    **article_v1,
+    "someNewField": int
+}
 
-    assert schema(article_v1) == response
+def test_article_v2_endpoint(test_client):
+    """
+    Test calling v2 endpoint is backwards compatible with v1
+    """
+    response_v2 = test_client.get("/api/v2/article/1")
+
+    assert like(article_v1) == value
 
 ```
 ## Full Example

--- a/src/pytest_schema/__init__.py
+++ b/src/pytest_schema/__init__.py
@@ -17,6 +17,8 @@ __all__ = [
     "schema",
     "like_schema",
     "exact_schema",
+    "like",
+    "exact",
     "And",
     "Enum",
     "Forbidden",

--- a/src/pytest_schema/helpers.py
+++ b/src/pytest_schema/helpers.py
@@ -1,12 +1,12 @@
-from typing import Any
+from typing import Any, List
+from schema import Or
 
 from pytest_schema.schema import Schema
 
 
 def schema(value: Any, **kargs) -> Schema:
     """
-    Helper to create an Schema class, accepting
-    all kargs to configure underlying Schema class.
+    Helper to create an Schema class, accepting all kargs to configure underlying Schema class.
 
     Args:
         value (Any): schema value to validation data against
@@ -58,5 +58,41 @@ def like_schema(value: Any) -> Schema:
         ✅ assert like_schema({ "status": int }) == {"status": 404}
         ❌ assert like_schema({ "status": int }) == {"status": "404"}
         ✅ assert like_schema({ "status": int }) == {"status": 404, "timestamp": 1594358256}
+    """
+    return schema(value, ignore_extra_keys=True)
+
+
+def like(value: Any) -> Schema:
+    """
+    Helper to create an Schema class with non exact match requirements.
+
+    Args:
+        value (Any): schema value to validation data against
+
+    Returns:
+        Schema: initialized and configured class with non exact match requirements
+
+    Example:
+        ✅ assert like({ "status": int }) == {"status": 404}
+        ❌ assert like({ "status": int }) == {"status": "404"}
+        ✅ assert like({ "status": int }) == {"status": 404, "timestamp": 1594358256}
+    """
+    return schema(value, ignore_extra_keys=True)
+
+
+def exact(value: Any) -> Schema:
+    """
+    Helper to create an Schema class with exact match requirements.
+
+    Args:
+        value (Any): schema value to validation data against
+
+    Returns:
+        Schema: initialized and configured class with exact match requirements
+
+    Example:
+        ✅ assert exact({ "status": int }) == {"status": 404}
+        ❌ assert exact({ "status": int }) == {"status": "404"}
+        ❌ assert exact({ "status": int }) == {"status": 404, "timestamp": 1594358256}
     """
     return schema(value, ignore_extra_keys=True)

--- a/src/pytest_schema/types.py
+++ b/src/pytest_schema/types.py
@@ -1,25 +1,24 @@
 from schema import And, Forbidden, Hook, Literal, Optional, Or, Regex, Use
 
-from pytest_schema.schema import Schema
 
+__all__ = [
+    "And",
+    "Forbidden",
+    "Hook",
+    "Literal",
+    "Optional",
+    "Or",
+    "Regex",
+    "Use",
+    "Enum"
+]
 
-class Enum(Schema):
-    """Simple interface to create Enum like schema."""
+class Enum(Or):
+    """
+    Patch interface of `Or` class with plans to expand the
+    interface to support different Enum-like workflows.
 
-    def __init__(self, *value):
-        """
-        Initialize schema with list or tuple like values.
-
-        Args:
-            *values (List[Any]): values in enum.
-
-        Example:
-
-            Enum([0, 1, 1, 2, 3, 5, 8])
-            Enum(["red", "blue", "green"])
-
-        """
-        if len(value) == 1 and hasattr(value[0], "__iter__"):
-            value = [v for v in value[0]]
-
-        super().__init__(value, ignore_extra_keys=False)
+    TODO: Support List[Any] constructor input
+    TODO: Support python Enum constructor input,
+        with value or name option.
+    """

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,0 +1,26 @@
+import pytest
+
+from pytest_schema import schema, Enum, SchemaError
+
+
+@pytest.mark.parametrize(
+    "values, expected",
+    [
+        (["red", "blue", "green"], "red"),
+        ([1, 2, 3], 3),
+    ],
+)
+def test_enum_valid(values, expected):
+    assert schema(Enum(*values)) == expected
+
+
+@pytest.mark.parametrize(
+    "values, expected",
+    [
+        (["red", "blue", "green"], "yellow"),
+        ([1, 2, 3], 5),
+    ],
+)
+def test_enum_not_valid(values, expected):
+    with pytest.raises(SchemaError):
+        assert schema(Enum(*values)) == expected


### PR DESCRIPTION
Reported in #1, we need to consider extending the Enum class to support different inputs. This has been noted in the TODO section of the constructor method. 

```python
Enum(1,2,3)
Enum("red", "green", "blue")
```
Please note at the moment we do not support `list` inputs, but is noted at something to add along with native Enum support (by name or by value or either).



FIXES: #1 